### PR TITLE
Update 00-compile.t

### DIFF
--- a/t/00-compile.t
+++ b/t/00-compile.t
@@ -3,7 +3,7 @@ use warnings;
 use Test::Compile;
 
 my @scripts = qw(mod2html podtree2html pods2html perl2html);
-my $test    = Test::Compile->new();
+my $test    = Test::Compile::Internal->new();
 $test->all_files_ok();
 $test->pl_file_compiles($_) for @scripts;
 $test->done_testing();


### PR DESCRIPTION
Running 'make test' I get:
t/00-compile.t ...... Can't locate object method "new" via package "Test::Compile" at t/00-compile.t line 6.

After changing that to:
Test::Compile::Internal->new();
I get:

t/00-compile.t ...... ok
