### PR TITLE
pods2html tests fail on Windows due to path interpolation into regex pattern

### DIFF
--- a/pods2html
+++ b/pods2html
@@ -99,7 +99,7 @@ sub Translate_POD {
 	my $depth = Depth($source);
 
 	my $pod = $source;
-	$pod =~ s(^$PodDir/)();
+	$pod =~ s(^\Q$PodDir\E/)();
 	$pod =~ s( \.\w+$ )()x;
 	$Index{$pod} = 1;
 


### PR DESCRIPTION
Use quotemeta to prevent misinterpration of path string by regex engine. See Issue #6.
